### PR TITLE
feat: add PayAI API key authentication to FacilitatorClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@payai/x402": "^2.2.1",
+        "@payai/x402": "^2.2.3",
         "@solana/spl-token": ">=0.4.14",
         "@solana/web3.js": ">=1.98.4",
         "zod": "^4.3.5"
@@ -2454,9 +2454,9 @@
       }
     },
     "node_modules/@payai/x402": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@payai/x402/-/x402-2.2.1.tgz",
-      "integrity": "sha512-F8dDYB9PKjZb4Dpx/tMWrDtgkWSFEdyQkVBEBTjqWRHHp60ujeZ9gAEpTnsXLvJTydXKhGWB/pECHEZyM/4dqw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@payai/x402/-/x402-2.2.3.tgz",
+      "integrity": "sha512-VrN5qshtYex7+zR5Jc0LZFSxr3kDVgRzIv1EgOvc9Obhs07mwrXiCfnoMbosd71Uq7cTQpB5c4V+u5YWlU1KMQ==",
       "license": "Proprietary",
       "dependencies": {
         "zod": "^3.24.2"
@@ -4316,21 +4316,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -9249,21 +9234,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/uuid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
-        "@payai/x402": "^2.2.3",
+        "@payai/facilitator": "^2.2.4",
+        "@payai/x402": "^2.2.4",
         "@solana/spl-token": ">=0.4.14",
         "@solana/web3.js": ">=1.98.4",
         "zod": "^4.3.5"
@@ -2453,10 +2454,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@payai/facilitator": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@payai/facilitator/-/facilitator-2.2.4.tgz",
+      "integrity": "sha512-y5Tx4kkzc0kOVv02mHjua0Is9FfITDoI6lUHc3Mh+HitBlBJImHWlnSAIL18gVxC/jl9AJ7b/7MQqpjfQ+XO5A==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@x402/core": ">=2.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/core": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@payai/x402": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@payai/x402/-/x402-2.2.3.tgz",
-      "integrity": "sha512-VrN5qshtYex7+zR5Jc0LZFSxr3kDVgRzIv1EgOvc9Obhs07mwrXiCfnoMbosd71Uq7cTQpB5c4V+u5YWlU1KMQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@payai/x402/-/x402-2.2.4.tgz",
+      "integrity": "sha512-P1ZVXTa4HMatsLaO2mU/mw0EnYpkw4uEshjsOIL0g1MgxDTxVDPNikNiYXFTs0ROttXCNQPZhu4KBcDcb0Ee2A==",
       "license": "Proprietary",
       "dependencies": {
         "zod": "^3.24.2"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@payai/facilitator": "^2.2.4",
-    "@payai/x402": "^2.2.3",
+    "@payai/x402": "^2.2.4",
     "@solana/spl-token": ">=0.4.14",
     "@solana/web3.js": ">=1.98.4",
     "zod": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "release": "npm run build && changeset publish"
   },
   "dependencies": {
+    "@payai/facilitator": "^1.0.0",
     "@payai/x402": "^2.2.3",
     "@solana/spl-token": ">=0.4.14",
     "@solana/web3.js": ">=1.98.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "release": "npm run build && changeset publish"
   },
   "dependencies": {
-    "@payai/x402": "^2.2.1",
+    "@payai/x402": "^2.2.3",
     "@solana/spl-token": ">=0.4.14",
     "@solana/web3.js": ">=1.98.4",
     "zod": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "release": "npm run build && changeset publish"
   },
   "dependencies": {
-    "@payai/facilitator": "^1.0.0",
+    "@payai/facilitator": "^2.2.4",
     "@payai/x402": "^2.2.3",
     "@solana/spl-token": ">=0.4.14",
     "@solana/web3.js": ">=1.98.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x402-solana",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A framework-agnostic implementation of the x402 payment protocol v2 for Solana clients (browsers) and servers",
   "keywords": [
     "x402",

--- a/src/server/facilitator-client.ts
+++ b/src/server/facilitator-client.ts
@@ -4,8 +4,9 @@ import type {
   VerifyResponse,
   SettleResponse,
   SupportedResponse,
-} from "@payai/x402/types";
-import { isSolanaNetwork } from "../types";
+} from '@payai/x402/types';
+import { getOrGenerateJwt } from '@payai/x402/auth';
+import { isSolanaNetwork } from '../types';
 
 /**
  * Facilitator supported kind (from /supported endpoint)
@@ -21,16 +22,60 @@ interface SupportedKind {
 }
 
 /**
- * Client for communicating with x402 facilitator service (v2)
+ * Configuration for the facilitator client
+ */
+interface FacilitatorClientConfig {
+  url: string;
+  /** PayAI API Key ID for JWT auth */
+  apiKeyId?: string | undefined;
+  /** PayAI API Key Secret for JWT auth */
+  apiKeySecret?: string | undefined;
+}
+
+/**
+ * Client for communicating with x402 facilitator service (v2).
+ *
+ * When `apiKeyId` and `apiKeySecret` are provided, all requests are
+ * automatically authenticated with a JWT Bearer token (cached and refreshed).
  */
 export class FacilitatorClient {
-  constructor(private facilitatorUrl: string) {}
+  private readonly facilitatorUrl: string;
+  private readonly apiKeyId: string | undefined;
+  private readonly apiKeySecret: string | undefined;
+
+  constructor(config: FacilitatorClientConfig) {
+    this.facilitatorUrl = config.url;
+    this.apiKeyId = config.apiKeyId;
+    this.apiKeySecret = config.apiKeySecret;
+  }
+
+  /**
+   * Build auth headers when API keys are configured.
+   * Returns an empty object when no keys are present.
+   */
+  private async getAuthHeaders(): Promise<Record<string, string>> {
+    if (!this.apiKeyId || !this.apiKeySecret) {
+      return {};
+    }
+
+    const jwt = await getOrGenerateJwt({
+      apiKeyId: this.apiKeyId,
+      apiKeySecret: this.apiKeySecret,
+    });
+
+    return { Authorization: `Bearer ${jwt}` };
+  }
 
   /**
    * Get supported payment kinds from facilitator
    */
   async getSupported(): Promise<SupportedResponse> {
-    const response = await fetch(`${this.facilitatorUrl}/supported`);
+    const authHeaders = await this.getAuthHeaders();
+
+    const response = await fetch(`${this.facilitatorUrl}/supported`, {
+      headers: { ...authHeaders },
+    });
+
     if (!response.ok) {
       throw new Error(`Facilitator /supported returned ${response.status}`);
     }
@@ -46,18 +91,17 @@ export class FacilitatorClient {
 
     // Look for network support - match by CAIP-2 prefix for Solana networks
     const networkSupport = (supportedData.kinds as SupportedKind[])?.find(
-      (kind) =>
-        kind.scheme === "exact" &&
+      kind =>
+        kind.scheme === 'exact' &&
         isSolanaNetwork(kind.network) &&
         isSolanaNetwork(network) &&
         // Match if both are same network type (mainnet or devnet)
-        (kind.network.includes("devnet") === network.includes("devnet") ||
-          kind.network === network),
+        (kind.network.includes('devnet') === network.includes('devnet') || kind.network === network)
     );
 
     if (!networkSupport?.extra?.feePayer) {
       throw new Error(
-        `Facilitator does not support network "${network}" with scheme "exact" or feePayer not provided`,
+        `Facilitator does not support network "${network}" with scheme "exact" or feePayer not provided`
       );
     }
 
@@ -70,12 +114,12 @@ export class FacilitatorClient {
    */
   async verifyPayment(
     paymentHeader: string,
-    paymentRequirements: PaymentRequirements,
+    paymentRequirements: PaymentRequirements
   ): Promise<VerifyResponse> {
     try {
       // Decode the base64 payment payload
       const paymentPayload: PaymentPayload = JSON.parse(
-        Buffer.from(paymentHeader, "base64").toString("utf8"),
+        Buffer.from(paymentHeader, 'base64').toString('utf8')
       );
 
       const verifyPayload = {
@@ -83,23 +127,23 @@ export class FacilitatorClient {
         paymentRequirements,
       };
 
+      const authHeaders = await this.getAuthHeaders();
+
       const response = await fetch(`${this.facilitatorUrl}/verify`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
+          ...authHeaders,
         },
         body: JSON.stringify(verifyPayload),
       });
 
       if (!response.ok) {
         const errorBody = await response.text();
-        console.error(
-          `Facilitator /verify returned ${response.status}:`,
-          errorBody,
-        );
+        console.error(`Facilitator /verify returned ${response.status}:`, errorBody);
         return {
           isValid: false,
-          invalidReason: "unexpected_verify_error",
+          invalidReason: 'unexpected_verify_error',
         };
       }
 
@@ -107,10 +151,10 @@ export class FacilitatorClient {
       const facilitatorResponse: VerifyResponse = await response.json();
       return facilitatorResponse;
     } catch (error) {
-      console.error("Payment verification failed:", error);
+      console.error('Payment verification failed:', error);
       return {
         isValid: false,
-        invalidReason: "unexpected_verify_error",
+        invalidReason: 'unexpected_verify_error',
       };
     }
   }
@@ -121,12 +165,12 @@ export class FacilitatorClient {
    */
   async settlePayment(
     paymentHeader: string,
-    paymentRequirements: PaymentRequirements,
+    paymentRequirements: PaymentRequirements
   ): Promise<SettleResponse> {
     try {
       // Decode the base64 payment payload
       const paymentPayload: PaymentPayload = JSON.parse(
-        Buffer.from(paymentHeader, "base64").toString("utf8"),
+        Buffer.from(paymentHeader, 'base64').toString('utf8')
       );
 
       const settlePayload = {
@@ -134,24 +178,24 @@ export class FacilitatorClient {
         paymentRequirements,
       };
 
+      const authHeaders = await this.getAuthHeaders();
+
       const response = await fetch(`${this.facilitatorUrl}/settle`, {
-        method: "POST",
+        method: 'POST',
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
+          ...authHeaders,
         },
         body: JSON.stringify(settlePayload),
       });
 
       if (!response.ok) {
         const errorBody = await response.text();
-        console.error(
-          `Facilitator /settle returned ${response.status}:`,
-          errorBody,
-        );
+        console.error(`Facilitator /settle returned ${response.status}:`, errorBody);
         return {
           success: false,
-          errorReason: "unexpected_settle_error",
-          transaction: "",
+          errorReason: 'unexpected_settle_error',
+          transaction: '',
           network: paymentRequirements.network,
         };
       }
@@ -160,11 +204,11 @@ export class FacilitatorClient {
       const facilitatorResponse: SettleResponse = await response.json();
       return facilitatorResponse;
     } catch (error) {
-      console.error("Payment settlement failed:", error);
+      console.error('Payment settlement failed:', error);
       return {
         success: false,
-        errorReason: "unexpected_settle_error",
-        transaction: "",
+        errorReason: 'unexpected_settle_error',
+        transaction: '',
         network: paymentRequirements.network,
       };
     }

--- a/src/server/facilitator-client.ts
+++ b/src/server/facilitator-client.ts
@@ -5,7 +5,7 @@ import type {
   SettleResponse,
   SupportedResponse,
 } from '@payai/x402/types';
-import { getOrGenerateJwt } from '@payai/x402/auth';
+import { getOrGenerateJwt } from '@payai/facilitator';
 import { isSolanaNetwork } from '../types';
 
 /**

--- a/src/types/solana-payment.ts
+++ b/src/types/solana-payment.ts
@@ -1,5 +1,5 @@
-import type { VersionedTransaction } from "@solana/web3.js";
-import type { SolanaNetworkSimple } from "./x402-protocol";
+import type { VersionedTransaction } from '@solana/web3.js';
+import type { SolanaNetworkSimple } from './x402-protocol';
 
 /**
  * Solana-specific payment types (v2)
@@ -62,6 +62,10 @@ export interface X402ServerConfig {
   treasuryAddress: string;
   /** Facilitator service URL */
   facilitatorUrl: string;
+  /** PayAI API Key ID -- enables automatic JWT auth (bypasses free tier limits). */
+  apiKeyId?: string;
+  /** PayAI API Key Secret (Ed25519 PKCS#8, raw base64 or `payai_sk_` prefixed). */
+  apiKeySecret?: string;
   /** Custom RPC URL (defaults to public endpoint) */
   rpcUrl?: string;
   /** Default token to accept (defaults to USDC) */


### PR DESCRIPTION
Add apiKeyId and apiKeySecret to X402ServerConfig and update FacilitatorClient to auto-inject JWT Bearer headers on all facilitator requests (/supported, /verify, /settle).

Uses getOrGenerateJwt from @payai/x402/auth for cached Ed25519 JWT generation. 

Merchants can now authenticate by adding two fields to their config:

  const handler = new X402PaymentHandler({
    network: "solana-devnet",
    treasuryAddress: "...",
    facilitatorUrl: "https://facilitator.payai.network",
    apiKeyId: process.env.PAYAI_API_KEY_ID,
    apiKeySecret: process.env.PAYAI_API_KEY_SECRET,
  });