### PR TITLE
fix: echo PaymentRequired extensions and resource into v2 payment payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- v2 client now echoes the 402 response's `extensions` and `resource` object
+  into the payment payload, as required by the x402 v2 specification. Without
+  the echo, facilitators never received Bazaar discovery declarations, so
+  resources paid through this client were never catalogued (#40, #36).
+  `createPaymentPayload` gains an optional fourth parameter carrying the parsed
+  `PaymentRequired`; existing three-argument callers keep the previous
+  behavior.
+
 ## 2.0.4
 
 ### Added

--- a/src/client/payment-interceptor.ts
+++ b/src/client/payment-interceptor.ts
@@ -128,11 +128,15 @@ export function createPaymentFetch(
     let headerName: string;
 
     if (protocolVersion === 2) {
-      // v2: Use PAYMENT-SIGNATURE header with full payload
+      // v2: Use PAYMENT-SIGNATURE header with full payload.
+      // Pass the parsed 402 response so its `resource` object and declared
+      // `extensions` (e.g. bazaar discovery) are echoed into the payload,
+      // as the v2 spec requires.
       paymentHeader = createPaymentPayload(
         signedTransaction,
         selectedRequirements,
         resourceUrl,
+        paymentRequired,
       );
       headerName = "PAYMENT-SIGNATURE";
     } else {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,9 @@
 import type { VersionedTransaction } from "@solana/web3.js";
-import type { PaymentRequirements, PaymentPayload } from "@payai/x402/types";
+import type {
+  PaymentRequired,
+  PaymentRequirements,
+  PaymentPayload,
+} from "@payai/x402/types";
 import {
   type TokenAsset,
   SOLANA_MAINNET_CAIP2,
@@ -19,25 +23,39 @@ const USDC_DEVNET = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
  * Create v2 payment payload from a signed transaction
  * Encodes transaction and payment details for PAYMENT-SIGNATURE header
  *
+ * Per the x402 v2 specification, the client must echo the server's declared
+ * `extensions` into the payment payload ("the client must include at least the
+ * info received; it may append additional info but cannot delete or overwrite
+ * existing info"). The `resource` object is likewise echoed verbatim so
+ * optional service metadata (`serviceName`, `tags`, `iconUrl`) survives.
+ * Without this echo, facilitators receive no Bazaar discovery info and the
+ * resource is never catalogued (see issue #40).
+ *
  * @param transaction - Signed Solana VersionedTransaction
  * @param paymentRequirements - The accepted payment requirements
- * @param resourceUrl - URL of the protected resource
+ * @param resourceUrl - URL of the protected resource (fallback when the 402
+ *   response's `resource` object is not provided)
+ * @param paymentRequired - The parsed 402 PaymentRequired response; its
+ *   `resource` and `extensions` are echoed into the payload when present
  * @returns Base64-encoded payment payload for PAYMENT-SIGNATURE header
  */
 export function createPaymentPayload(
   transaction: VersionedTransaction,
   paymentRequirements: PaymentRequirements,
   resourceUrl: string,
+  paymentRequired?: Pick<PaymentRequired, "resource" | "extensions">,
 ): string {
   // Serialize the signed transaction to base64
   const base64Transaction = Buffer.from(transaction.serialize()).toString(
     "base64",
   );
 
-  // Create v2 payment payload
+  // Create v2 payment payload. Prefer the server's own resource object; fall
+  // back to synthesizing one from the request URL for callers that only have
+  // the payment requirements (pre-existing behavior).
   const paymentPayload: PaymentPayload = {
     x402Version: 2,
-    resource: {
+    resource: paymentRequired?.resource ?? {
       url: resourceUrl,
       description: (paymentRequirements.extra?.description as string) || "",
       mimeType:
@@ -47,6 +65,12 @@ export function createPaymentPayload(
     payload: {
       transaction: base64Transaction,
     },
+    // Echo server-declared extensions (e.g. bazaar discovery). Omitted when
+    // the server declared none, keeping the payload byte-identical for the
+    // extension-less case.
+    ...(paymentRequired?.extensions !== undefined
+      ? { extensions: paymentRequired.extensions }
+      : {}),
   };
 
   // Encode payment payload as base64 for PAYMENT-SIGNATURE header

--- a/tests/extensions-echo.test.ts
+++ b/tests/extensions-echo.test.ts
@@ -1,0 +1,103 @@
+/**
+ * End-to-end test for PaymentRequired echo through the payment interceptor.
+ *
+ * v2 spec: servers advertise extensions in PaymentRequired and clients echo
+ * them in PaymentPayload. Regression coverage for issue #40, where the client
+ * dropped `extensions` (and synthesized `resource`), so facilitators never
+ * received bazaar discovery info and resources were never catalogued.
+ *
+ * The transaction builder is mocked so the flow deterministically reaches the
+ * retry request, unlike the soft assertions in v2-headers.test.ts.
+ */
+
+import { createX402Client } from '../src/client';
+import { mockWallet, encodePaymentRequired, decodePaymentHeader, createSuccessResponse } from './fixtures';
+
+jest.mock('../src/client/transaction-builder', () => ({
+  createSolanaPaymentTransaction: jest.fn().mockResolvedValue({
+    serialize: () => new Uint8Array([9, 9, 9]),
+  }),
+}));
+
+const bazaarExtensions = {
+  bazaar: {
+    info: {
+      input: { type: 'http', method: 'GET', queryParams: { q: 'string' } },
+      output: { type: 'json' },
+    },
+    schema: { type: 'object' },
+  },
+};
+
+const serverResource = {
+  url: 'https://api.example.com/canonical/endpoint',
+  description: 'Canonical description from the 402 response',
+  mimeType: 'application/json',
+  serviceName: 'Example Service',
+  tags: ['data'],
+  iconUrl: 'https://api.example.com/icon.png',
+};
+
+const paymentRequired = {
+  x402Version: 2,
+  error: 'PAYMENT-SIGNATURE header is required',
+  resource: serverResource,
+  accepts: [
+    {
+      scheme: 'exact',
+      network: 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1',
+      amount: '1000000',
+      asset: '4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU',
+      payTo: 'TestPayToAddress1234567890123456789012345678',
+      maxTimeoutSeconds: 60,
+      extra: {},
+    },
+  ],
+  extensions: bazaarExtensions,
+};
+
+describe('PaymentRequired echo through the interceptor', () => {
+  it('echoes extensions and resource from the 402 into the PAYMENT-SIGNATURE payload', async () => {
+    let sentPayload: Record<string, unknown> | null = null;
+
+    const customFetch = async (
+      _url: string | RequestInfo,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const headers = init?.headers as Record<string, string> | undefined;
+
+      if (headers?.['PAYMENT-SIGNATURE']) {
+        sentPayload = decodePaymentHeader(headers['PAYMENT-SIGNATURE']) as Record<
+          string,
+          unknown
+        >;
+        return createSuccessResponse();
+      }
+
+      return new Response(JSON.stringify({ message: 'Payment required' }), {
+        status: 402,
+        headers: {
+          'Content-Type': 'application/json',
+          'PAYMENT-REQUIRED': encodePaymentRequired(paymentRequired),
+        },
+      });
+    };
+
+    const client = createX402Client({
+      wallet: mockWallet,
+      network: 'solana-devnet',
+      customFetch,
+      verbose: false,
+    });
+
+    const response = await client.fetch('https://test-api.com/endpoint');
+
+    expect(response.status).toBe(200);
+    expect(sentPayload).not.toBeNull();
+    // The heart of issue #40: server-declared extensions must survive the echo
+    expect(sentPayload!.extensions).toEqual(bazaarExtensions);
+    // And the resource object is echoed verbatim, not synthesized client-side
+    expect(sentPayload!.resource).toEqual(serverResource);
+    expect(sentPayload!.x402Version).toBe(2);
+  });
+});

--- a/tests/utils/payload.test.ts
+++ b/tests/utils/payload.test.ts
@@ -87,6 +87,87 @@ describe('Payment Payload Creation', () => {
 
       expect(decoded.resource.mimeType).toBe('text/plain');
     });
+
+    // v2 spec: "Servers advertise supported extensions in PaymentRequired, and
+    // clients echo them in PaymentPayload. The client must include at least
+    // the info received." Dropping the echo means facilitators never see
+    // bazaar discovery info and the resource is never catalogued (issue #40).
+    describe('PaymentRequired echo', () => {
+      const bazaarExtensions = {
+        bazaar: {
+          info: {
+            input: { type: 'http', method: 'GET', queryParams: { q: 'string' } },
+            output: { type: 'json' },
+          },
+          schema: { type: 'object' },
+        },
+      };
+
+      const serverResource = {
+        url: 'https://api.example.com/canonical/test',
+        description: 'Server-declared description',
+        mimeType: 'application/json',
+        serviceName: 'Example Service',
+        tags: ['data', 'search'],
+        iconUrl: 'https://api.example.com/icon.png',
+      };
+
+      it('echoes server-declared extensions into the payload', () => {
+        const result = createPaymentPayload(mockTx as never, requirements, resourceUrl, {
+          resource: serverResource,
+          extensions: bazaarExtensions,
+        });
+        const decoded = decodePaymentHeader(result) as {
+          extensions: Record<string, unknown>;
+        };
+
+        expect(decoded.extensions).toEqual(bazaarExtensions);
+      });
+
+      it('echoes the server resource object verbatim, preserving service metadata', () => {
+        const result = createPaymentPayload(mockTx as never, requirements, resourceUrl, {
+          resource: serverResource,
+          extensions: bazaarExtensions,
+        });
+        const decoded = decodePaymentHeader(result) as { resource: typeof serverResource };
+
+        // Verbatim echo — including optional serviceName/tags/iconUrl fields
+        // that are not part of the base ResourceInfo type
+        expect(decoded.resource).toEqual(serverResource);
+      });
+
+      it('omits the extensions key entirely when the server declared none', () => {
+        const result = createPaymentPayload(mockTx as never, requirements, resourceUrl, {
+          resource: serverResource,
+        });
+        const decoded = decodePaymentHeader(result) as Record<string, unknown>;
+
+        expect('extensions' in decoded).toBe(false);
+      });
+
+      it('preserves an explicitly empty extensions object', () => {
+        // {} is a server declaration ("no extensions") and distinct from the
+        // field being absent; echo it as received.
+        const result = createPaymentPayload(mockTx as never, requirements, resourceUrl, {
+          resource: serverResource,
+          extensions: {},
+        });
+        const decoded = decodePaymentHeader(result) as Record<string, unknown>;
+
+        expect(decoded.extensions).toEqual({});
+      });
+
+      it('keeps the synthesized-resource fallback when paymentRequired is not given', () => {
+        const result = createPaymentPayload(mockTx as never, requirements, resourceUrl);
+        const decoded = decodePaymentHeader(result) as {
+          resource: { url: string };
+          extensions?: unknown;
+        };
+
+        expect(decoded.resource.url).toBe(resourceUrl);
+        expect(decoded.extensions).toBeUndefined();
+      });
+    });
   });
 
   describe('createPaymentPayloadV1', () => {


### PR DESCRIPTION
## Summary

Fixes #40 and #36: the v2 client dropped `extensions` from the payment payload and synthesized `resource` from `extra`, so facilitators never received Bazaar discovery declarations and resources paid through this client were never catalogued.

## Spec alignment

- x402 v2 spec (`specs/x402-specification-v2.md`): *"Servers advertise supported extensions in `PaymentRequired`, and clients echo them in `PaymentPayload`. The client must include at least the info received."*
- Bazaar spec (`specs/extensions/bazaar.md`, Client Behavior): *"Clients are expected to echo the `bazaar` extension from `PaymentRequired` into their `PaymentPayload`. If the extension is omitted, discovery cataloging will not occur."*
- Upstream reference client (`x402Client.ts`) builds `{ x402Version, payload, extensions, resource: paymentRequired.resource, accepted }` — this PR matches that shape.

## Changes

- `createPaymentPayload` gains an optional 4th param: the parsed `PaymentRequired`. Its `extensions` are echoed as received (an explicitly-empty `{}` is preserved; the key is omitted when the server declared none) and its `resource` object is echoed **verbatim**, so optional service metadata (`serviceName`, `tags`, `iconUrl`) survives.
- The payment interceptor passes the parsed 402 through.
- Three-argument callers keep the previous synthesized-resource behavior — no breaking change.

## Tests

- 5 new unit tests on `createPaymentPayload` (echo, verbatim resource, omission, empty-object preservation, fallback).
- New deterministic end-to-end test (`tests/extensions-echo.test.ts`) that mocks the transaction builder so the flow reliably reaches the retry, then decodes the `PAYMENT-SIGNATURE` header and asserts the echoed `extensions` and `resource` — unlike the soft conditional assertions in `v2-headers.test.ts`.
- Full suite: 92/92, tsc clean, eslint clean, build clean.

## Verification path for reporters

After this ships, the facilitator's new `EXTENSION-RESPONSES` header (live since 2026-07-29) flips from **absent** to `{"bazaar":{"status":"processing"}}` on `/verify` and `/settle` for bazaar-declaring sellers — the exact signature @ayubeay's controlled experiment established in #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)