### PR TITLE
fix: unbreak the release workflow and add the missing changeset for 2.0.5

### DIFF
--- a/.changeset/echo-payment-required-extensions.md
+++ b/.changeset/echo-payment-required-extensions.md
@@ -1,0 +1,5 @@
+---
+"x402-solana": patch
+---
+
+v2 client now echoes the 402 response's `extensions` and `resource` object into the payment payload, as required by the x402 v2 specification. Without the echo, facilitators never received Bazaar discovery declarations, so resources paid through this client were never catalogued (#40, #36). `createPaymentPayload` gains an optional fourth parameter carrying the parsed `PaymentRequired`; existing three-argument callers keep the previous behavior.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup npm cache
@@ -62,11 +62,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Update npm to latest
-        run: npm install -g npm@latest
 
       - name: Setup npm cache
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-
-- v2 client now echoes the 402 response's `extensions` and `resource` object
-  into the payment payload, as required by the x402 v2 specification. Without
-  the echo, facilitators never received Bazaar discovery declarations, so
-  resources paid through this client were never catalogued (#40, #36).
-  `createPaymentPayload` gains an optional fourth parameter carrying the parsed
-  `PaymentRequired`; existing three-argument callers keep the previous
-  behavior.
-
 ## 2.0.4
 
 ### Added


### PR DESCRIPTION
## Why the #41 release failed

Two independent problems, both fixed here:

1. **Workflow rot.** The Release job pins Node 20 and runs `npm install -g npm@latest`. npm@12 (current latest) requires Node ≥22, so the step dies with `EBADENGINE` before reaching the changesets step ([failed run](https://github.com/PayAINetwork/x402-solana/actions/runs/30680350522)). Both jobs now use Node 22, and the update-to-latest step is dropped — installing an unpinned npm at release time is exactly the fragility that broke this, and Node 22's bundled npm handles `--provenance` publishes fine.

2. **Missing changeset.** #41 shipped without a `.changeset/*.md`, so even a green job would have published nothing (changesets had no pending release). Added the patch changeset; the hand-written `Unreleased` section is moved out of CHANGELOG.md since changesets generates the release entry.

## What happens on merge

The Release job should create the `chore: version packages` PR (bumping to 2.0.5 with the changelog entry). Merging *that* PR publishes 2.0.5 to npm with the extension-echo fix from #41.

92/92 tests pass on Node 22 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)