### PR TITLE
fix: restore OIDC-capable npm in the release job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,14 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      # This package publishes via npm trusted publishing (OIDC) — no NPM_TOKEN
+      # secret exists on the repo. OIDC publish requires npm >= 11.5.1, but
+      # Node 22 bundles npm 10.x, which silently falls back to token auth and
+      # dies with ENEEDAUTH. Pinned to a major (not @latest) so a future npm
+      # release with a higher Node floor can't break this job again.
+      - name: Install OIDC-capable npm
+        run: npm install -g npm@11
+
       - name: Setup npm cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## What happened

The 2.0.5 publish run failed with `ENEEDAUTH` after building a correct tarball.

## Root cause

This package publishes via **npm trusted publishing (OIDC)** — 2.0.4's npm user is `npm-oidc-no-reply@github.com`, and the repo has **no** `NPM_TOKEN` secret (`gh secret list` is empty). OIDC publish requires **npm ≥ 11.5.1**.

#42 removed the `npm install -g npm@latest` step as pure fragility after it broke on Node 20 + npm@12's engine floor. That was half right: unpinned `@latest` against a pinned Node was the fragility, but the step itself was load-bearing — it provided the OIDC-capable npm. Node 22's bundled npm 10.x silently falls back to token auth, finds none, and dies.

## Fix

Restore the upgrade **pinned to `npm@11`** (supports Node 22; trusted publishing since 11.5.1), with a comment explaining why the step exists so it doesn't get cleaned away again. A future npm major raising its Node floor can no longer break the job.

## After merge

The Release run on `main` will retry the 2.0.5 publish (version is already bumped on main from #43; the changesets action sees no pending changesets and publishes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)